### PR TITLE
Improve Discogs extraction and import

### DIFF
--- a/soweego/commons/db_manager.py
+++ b/soweego/commons/db_manager.py
@@ -17,6 +17,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
 
 from soweego.commons import constants as const
 from soweego.commons import localizations as loc
@@ -40,10 +41,10 @@ class DBManager():
         password = credentials[const.PASSWORD_KEY]
         host = credentials[const.HOST_KEY]
         try:
+            # Disable connection pooling, as per Wikimedia policy
+            # https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database#Connection_handling_policy
             self.__engine = create_engine(
-                '{0}://{1}:{2}@{3}/{4}'.format(db_engine,
-                                               user, password, host, db_name),
-                echo=False)
+                '{0}://{1}:{2}@{3}/{4}'.format(db_engine, user, password, host, db_name), poolclass=NullPool)
         except Exception as error:
             LOGGER.critical(loc.FAIL_CREATE_ENGINE, error)
 

--- a/soweego/commons/url_utils.py
+++ b/soweego/commons/url_utils.py
@@ -22,6 +22,9 @@ from urllib3.exceptions import InsecureRequestWarning
 
 LOGGER = logging.getLogger(__name__)
 
+# HTTP requests timeout in seconds
+READ_TIMEOUT = 10
+
 # URLs stopwords
 TOP_LEVEL_DOMAINS = set(['com', 'org', 'net', 'info', 'fm'])
 DOMAIN_PREFIXES = set(['www', 'm', 'mobile'])
@@ -101,7 +104,8 @@ def resolve(url):
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:62.0) Gecko/20100101 Firefox/62.0'}
     try:
         # Some Web sites do not accept the HEAD method: fire a GET, but don't download anything
-        response = get(url, headers=browser_ua, stream=True)
+        response = get(url, headers=browser_ua,
+                       stream=True, timeout=READ_TIMEOUT)
     except requests.exceptions.SSLError as ssl_error:
         LOGGER.debug(
             'SSL certificate verification failed, will retry without verification. Original URL: <%s> - Reason: %s', url, ssl_error)
@@ -111,13 +115,17 @@ def resolve(url):
             LOGGER.warning(
                 'Dropping URL that led to an unexpected error: <%s> - Reason: %s', url, unexpected_error)
             return None
-    except requests.exceptions.ConnectionError as connection_error:
+    except requests.exceptions.Timeout as timeout:
         LOGGER.info(
-            'Dropping URL that led to an aborted connection: <%s> - Reason: %s', url, connection_error)
+            'Dropping URL that led to a request timeout: <%s> - Reason: %s', url, timeout)
         return None
     except requests.exceptions.TooManyRedirects as too_many_redirects:
         LOGGER.info(
             'Dropping URL because of too many redirects: <%s> - %s', url, too_many_redirects)
+        return None
+    except requests.exceptions.ConnectionError as connection_error:
+        LOGGER.info(
+            'Dropping URL that led to an aborted connection: <%s> - Reason: %s', url, connection_error)
         return None
     except Exception as unexpected_error:
         LOGGER.warning(

--- a/soweego/importer/discogs_dump_extractor.py
+++ b/soweego/importer/discogs_dump_extractor.py
@@ -20,6 +20,7 @@ from soweego.commons import text_utils, url_utils
 from soweego.commons.db_manager import DBManager
 from soweego.importer.base_dump_extractor import BaseDumpExtractor
 from soweego.importer.models import discogs_entity
+from soweego.importer.models.base_link_entity import BaseLinkEntity
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +60,8 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
                   discogs_entity.DiscogsGroupEntity, discogs_entity.DiscogsGroupNlpEntity, discogs_entity.DiscogsGroupLinkEntity]
 
         db_manager = DBManager()
+        LOGGER.info('Connected to database: %s', db_manager.get_engine().url)
+
         db_manager.drop(tables)
         db_manager.create(tables)
         LOGGER.info('SQL tables dropped and re-created: %s',
@@ -81,6 +84,8 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
                         'Skipping import for identifier with no name: %s', identifier)
                     continue
 
+                living_links = self._extract_living_links(node, identifier)
+
                 session = db_manager.new_session()
 
                 # Musician
@@ -89,32 +94,32 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
                 if groups:
                     entity = discogs_entity.DiscogsMusicianEntity()
                     self._populate_musician(
-                        entity, identifier, name, node, session)
+                        entity, identifier, name, living_links, node, session)
                 # Band
                 elif members:
                     entity = discogs_entity.DiscogsGroupEntity()
                     self._populate_band(entity, identifier,
-                                        name, node, session)
+                                        name, living_links, node, session)
                 # Can't infer the entity type, so populate both
                 else:
                     LOGGER.debug(
                         'Unknown artist type. Will add it to both musicians and bands: %s', identifier)
                     entity = discogs_entity.DiscogsMusicianEntity()
                     self._populate_musician(
-                        entity, identifier, name, node, session)
+                        entity, identifier, name, living_links, node, session)
                     entity = discogs_entity.DiscogsGroupEntity()
                     self._populate_band(entity, identifier,
-                                        name, node, session)
+                                        name, living_links, node, session)
 
                 session.commit()
-                LOGGER.critical('Total entities added to the DB: %d. %d musicians with %d links, %d bands with %d links, %d discarded dead links.',
-                                self.total_entities, self.musicians, self.musician_links, self.bands, self.band_links, self.dead_links)
+                LOGGER.debug('%d entities imported so far: %d musicians with %d links, %d bands with %d links, %d discarded dead links.',
+                             self.total_entities, self.musicians, self.musician_links, self.bands, self.band_links, self.dead_links)
 
         end = datetime.now()
-        LOGGER.info('Import completed in %d. Total entities: %d. %d musicians with %d links, %d bands with %d links, %d discarded dead links.',
+        LOGGER.info('Import completed in %d. Total entities: %d - %d musicians with %d links - %d bands with %d links - %d discarded dead links.',
                     end - start, self.total_entities, self.musicians, self.musician_links, self.bands, self.band_links, self.dead_links)
 
-    def _populate_band(self, entity, identifier, name, node, session):
+    def _populate_band(self, entity: discogs_entity.DiscogsGroupEntity, identifier, name, links, node, session):
         # Main entity
         self._fill_entity(entity, identifier, name, node)
         session.add(entity)
@@ -126,13 +131,14 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
         # Denormalized name variations
         self._populate_name_variations(session, node, entity, identifier)
         # Links
-        self._populate_links(
-            session, node, discogs_entity.DiscogsGroupLinkEntity, identifier)
+        for link in links:
+            self._fill_link_entity(
+                discogs_entity.DiscogsMusicianLinkEntity(), identifier, link)
         # TODO populate group -> musicians relationship table
         #  for member in list(members):
         #      get member.attrib['id']
 
-    def _populate_musician(self, entity, identifier, name, node, session):
+    def _populate_musician(self, entity: discogs_entity.DiscogsMusicianEntity, identifier, name, links, node, session):
         # Main entity
         self._fill_entity(entity, identifier, name, node)
         session.add(entity)
@@ -144,8 +150,9 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
         # Denormalized name variations
         self._populate_name_variations(session, node, entity, identifier)
         # Links
-        self._populate_links(
-            session, node, discogs_entity.DiscogsMusicianLinkEntity, identifier)
+        for link in links:
+            self._fill_link_entity(
+                discogs_entity.DiscogsMusicianLinkEntity(), identifier, link)
         # TODO populate musician -> groups relationship table
         #  for group in list(groups):
         #      get group.attrib['id']
@@ -219,42 +226,43 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
                 self.bands += 1
             yield variation_entity
 
-    def _populate_links(self, session, artist_node, entity_class, identifier):
+    def _extract_living_links(self, artist_node, identifier):
+        LOGGER.debug('Extracting living links from artist %s', identifier)
         urls = artist_node.find('urls')
         if urls:
             for url_element in urls.iterfind('url'):
                 url = url_element.text
-                if url:
-                    session.add_all(self._fill_clean_link(
-                        url, identifier, entity_class))
-                else:
+                if not url:
                     LOGGER.debug(
                         'Artist %s: skipping empty <url> tag', identifier)
                     continue
+                for alive_link in self._check_link(url):
+                    yield alive_link
 
-    def _fill_clean_link(self, url, identifier, entity_class):
-        LOGGER.debug('Processing URL <%s>', url)
-        clean_parts = url_utils.clean(url)
-        LOGGER.debug('Clean URL: %s', clean_parts)
+    def _check_link(self, link):
+        LOGGER.debug('Processing link <%s>', link)
+        clean_parts = url_utils.clean(link)
+        LOGGER.debug('Clean link: %s', clean_parts)
         for part in clean_parts:
-            valid_url = url_utils.validate(part)
-            if not valid_url:
+            valid = url_utils.validate(part)
+            if not valid:
                 self.dead_links += 1
                 continue
-            LOGGER.debug('Valid URL: <%s>', valid_url)
-            resolved = url_utils.resolve(valid_url)
-            if not resolved:
+            LOGGER.debug('Valid URL: <%s>', valid)
+            alive = url_utils.resolve(valid)
+            if not alive:
                 self.dead_links += 1
                 continue
-            LOGGER.debug('Living URL: <%s>', resolved)
-            link_entity = entity_class()
-            link_entity.catalog_id = identifier
-            link_entity.url = resolved
-            link_entity.is_wiki = url_utils.is_wiki_link(resolved)
-            link_entity.tokens = '|'.join(url_utils.tokenize(resolved))
+            LOGGER.debug('Living URL: <%s>', alive)
             self.valid_links += 1
-            if 'Musician' in entity_class.__name__:
-                self.musician_links += 1
-            else:
-                self.band_links += 1
-            yield link_entity
+            yield alive
+
+    def _fill_link_entity(self, entity: BaseLinkEntity, identifier, url):
+        entity.catalog_id = identifier
+        entity.url = url
+        entity.is_wiki = url_utils.is_wiki_link(url)
+        entity.tokens = '|'.join(url_utils.tokenize(url))
+        if isinstance(entity, discogs_entity.DiscogsMusicianLinkEntity):
+            self.musician_links += 1
+        elif isinstance(entity, discogs_entity.DiscogsGroupLinkEntity):
+            self.band_links += 1

--- a/soweego/importer/discogs_dump_extractor.py
+++ b/soweego/importer/discogs_dump_extractor.py
@@ -131,9 +131,8 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
         # Denormalized name variations
         self._populate_name_variations(session, node, entity, identifier)
         # Links
-        for link in links:
-            self._fill_link_entity(
-                discogs_entity.DiscogsMusicianLinkEntity(), identifier, link)
+        self._populate_links(
+            session, links, discogs_entity.DiscogsGroupLinkEntity, identifier)
         # TODO populate group -> musicians relationship table
         #  for member in list(members):
         #      get member.attrib['id']
@@ -150,12 +149,17 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
         # Denormalized name variations
         self._populate_name_variations(session, node, entity, identifier)
         # Links
-        for link in links:
-            self._fill_link_entity(
-                discogs_entity.DiscogsMusicianLinkEntity(), identifier, link)
+        self._populate_links(
+            session, links, discogs_entity.DiscogsMusicianLinkEntity, identifier)
         # TODO populate musician -> groups relationship table
         #  for group in list(groups):
         #      get group.attrib['id']
+
+    def _populate_links(self, session, links, entity_class, identifier):
+        for link in links:
+            link_entity = entity_class()
+            self._fill_link_entity(link_entity, identifier, link)
+            session.add(link_entity)
 
     def _populate_name_variations(self, session, artist_node, current_entity, identifier):
         name_variations_node = artist_node.find('namevariations')


### PR DESCRIPTION
- validate URLs first, then populate the DB;
- set a connection timeout for URL validation;
- disable DB connection pooling to comply with the Wikimedia Toolforge policy.