### PR TITLE
First version of the validator module

### DIFF
--- a/soweego/commons/cache.py
+++ b/soweego/commons/cache.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Adapted from https://github.com/Wikidata/StrepHit/blob/master/strephit/commons/cache.py
+
+"""Caching facility"""
+
+__author__ = 'Marco Fossati'
+__email__ = 'fossati@spaziodati.eu'
+__version__ = '1.0'
+__license__ = 'GPL-3.0'
+__copyright__ = 'Copyleft 2018, Hjfocs'
+
+import hashlib
+import json
+import os
+import tempfile
+
+BASE_DIR = os.path.join(tempfile.gettempdir(), 'soweego_cache')
+ENABLED = True
+
+
+def _hash_for(key):
+    return hashlib.sha1(key.encode('utf8')).hexdigest()
+
+
+def _path_for(hashed_key):
+    """ Computes the path in which the given key should be stored.
+
+        :return: tuple (full path, base path, file name)
+        :rtype: tuple
+    """
+    loc = os.path.join(BASE_DIR, hashed_key[:3])
+    return os.path.join(loc, hashed_key), loc, hashed_key
+
+
+def get_value(key, default=None):
+    """ Retrieves an item from the cache
+
+        :param key: Key of the item
+        :param default: Default value to return if the
+         key is not in the cache
+        :return: The item associated with the given key or
+         the default value
+
+        Sample usage:
+
+        >>> from soweego.commons import cache
+        >>> cache.get_value('kk', 13)
+        13
+        >>> cache.get_value('kk', 0)
+        0
+        >>> cache.set_value('kk', 15)
+        >>> cache.get_value('kk', 0)
+        15
+    """
+    if not ENABLED:
+        return default
+
+    hashed = _hash_for(key)
+    loc, _, _ = _path_for(hashed)
+    if os.path.exists(loc):
+        with open(loc) as f:
+            stored_key = f.readline()[:-1]
+            if stored_key == key:
+                return json.loads(f.read())
+            return get_value(key + hashed, default)
+    else:
+        return default
+
+
+def set_value(key, value, overwrite=True):
+    """ Stores an item in the cache under the given key
+
+        :param key: Unique key used to identify the idem.
+        :param value: Value to store in the cache. Must be
+        a generator of JSON-dumpable objects
+        :param overwrite: Whether to overwrite the previous
+        value associated with the key (if any)
+        :return: Nothing
+
+        Sample usage:
+
+        >>> from soweego.commons import cache
+        >>> cache.get_value('kk', 13)
+        13
+        >>> cache.get_value('kk', 0)
+        0
+        >>> cache.set_value('kk', 15)
+        >>> cache.get_value('kk', 0)
+        15
+    """
+    if not ENABLED:
+        return
+
+    hashed = _hash_for(key)
+    loc, path, _ = _path_for(hashed)
+    if not os.path.exists(loc):
+        if not os.path.exists(path):
+            try:
+                os.makedirs(path)
+            except OSError:
+                pass
+
+        with open(loc, 'w') as f:
+            f.write(key + '\n')
+            f.write(json.dumps([obj for obj in value]))
+    else:
+        with open(loc, 'r+') as f:
+            stored_key = f.readline()[:-1]
+            if stored_key == key:
+                if overwrite:
+                    f.write(json.dumps([obj for obj in value]))
+                    f.truncate()
+                return
+        set_value(key + hashed, value, overwrite)
+
+
+def cached(function):
+    """ Decorator to cache function results based on its arguments
+
+    Sample usage:
+
+    >>> from soweego.commons.cache import cached
+    >>> @cached
+    ... def f(x):
+    ...     print('inside f')
+    ...     return 2 * x
+    ...
+    >>> f(10)
+    inside f
+    20
+    >>> f(10)
+    20
+
+    """
+    def wrapper(*args, **kwargs):
+        key = str([function.__module__]) + \
+            function.__name__ + str(args) + str(kwargs)
+        res = get_value(key)
+        if res is None:
+            res = function(*args, **kwargs)
+            if res is not None:
+                set_value(key, res)
+        return res
+    return wrapper

--- a/soweego/commons/constants.py
+++ b/soweego/commons/constants.py
@@ -27,7 +27,6 @@ HANDLED_ENTITIES = {
 }
 
 # TODO add IMDb entities
-# TODO add MusicBrainz NLP entities
 # DB entities and their Wikidata class QID
 TARGET_CATALOGS = {
     'discogs': {

--- a/soweego/commons/constants.py
+++ b/soweego/commons/constants.py
@@ -17,6 +17,7 @@ USER_KEY = 'USER'
 PASSWORD_KEY = 'PASSWORD'
 HOST_KEY = 'HOST'
 
+# Entity types and corresponding Wikidata query
 HANDLED_ENTITIES = {
     'band': 'class',
     'musician': 'occupation',
@@ -25,9 +26,9 @@ HANDLED_ENTITIES = {
     'producer': 'occupation'
 }
 
-# What soweego handles
 # TODO add IMDb entities
 # TODO add MusicBrainz NLP entities
+# DB entities and their Wikidata class QID
 TARGET_CATALOGS = {
     'discogs': {
         'musician': {
@@ -64,7 +65,6 @@ TARGET_CATALOGS = {
         }
     },
     'musicbrainz': {
-        # FIXME is it correct?
         'musician': {
             'qid': vocabulary.MUSICIAN,
             'entity': musicbrainz_entity.MusicbrainzPersonEntity,

--- a/soweego/commons/logging.py
+++ b/soweego/commons/logging.py
@@ -13,7 +13,6 @@ __copyright__ = 'Copyleft 2018, Hjfocs'
 import logging
 import logging.config
 import os
-from datetime import datetime
 from urllib.parse import unquote_plus
 
 LEVELS = {

--- a/soweego/commons/logging.py
+++ b/soweego/commons/logging.py
@@ -13,6 +13,7 @@ __copyright__ = 'Copyleft 2018, Hjfocs'
 import logging
 import logging.config
 import os
+from datetime import datetime
 from urllib.parse import unquote_plus
 
 LEVELS = {
@@ -50,7 +51,7 @@ DEFAULT_CONFIG = {
         'debug_file_handler': {
             'formatter': 'soweego',
             'level': 'DEBUG',
-            'filename': 'soweego.log',
+            'filename': 'debug.log',
             'mode': 'w',
             'class': 'logging.FileHandler',
             'encoding': 'utf8'

--- a/soweego/validator/checks.py
+++ b/soweego/validator/checks.py
@@ -19,6 +19,7 @@ import regex
 from sqlalchemy import or_
 
 from soweego.commons import url_utils
+from soweego.commons.cache import cached
 from soweego.commons.constants import HANDLED_ENTITIES, TARGET_CATALOGS
 from soweego.commons.db_manager import DBManager
 from soweego.importer.models.base_entity import BaseEntity
@@ -84,135 +85,229 @@ def _connect_to_db():
 @click.command()
 @click.argument('entity', type=click.Choice(HANDLED_ENTITIES.keys()))
 @click.argument('catalog', type=click.Choice(TARGET_CATALOGS.keys()))
-@click.option('--wikidata-dump/--no-wikidata-dump', default=False, help='Dump links gathered from Wikidata')
-@click.option('--upload/--no-upload', default=True, help='Upload check results to Wikidata')
-@click.option('--sandbox/--no-sandbox', default=False, help='Upload to the Wikidata sandbox item Q4115189')
-@click.option('-d', '--deprecated-outfile', type=click.File('w'), default='output/deprecated_ids.json', help="default: 'output/deprecated_ids.json'")
-@click.option('-e', '--ext-ids-outfile', type=click.File('w'), default='output/external_ids_to_be_added.tsv', help="default: 'output/external_ids_to_be_added.tsv'")
-@click.option('-u', '--urls-outfile', type=click.File('w'), default='output/urls_to_be_added.tsv', help="default: 'output/urls_to_be_added.tsv'")
-@click.option('-w', '--wikidata-outfile', type=click.File('w'), default='output/wikidata_links.json', help="default: 'output/wikidata_links.json'")
-def check_links_cli(entity, catalog, wikidata_dump, upload, sandbox, deprecated_outfile, ext_ids_outfile, urls_outfile, wikidata_outfile):
+@click.option('--wikidata-dump/--no-wikidata-dump', default=False, help='Dump links gathered from Wikidata. Default: no.')
+@click.option('--upload/--no-upload', default=True, help='Upload check results to Wikidata. Default: yes.')
+@click.option('--sandbox/--no-sandbox', default=False, help='Upload to the Wikidata sandbox item Q4115189. Default: no.')
+@click.option('-c', '--cache', type=click.File(), default=None, help="Load Wikidata links previously dumped via '-w'. Default: no.")
+@click.option('-d', '--deprecated', type=click.File('w'), default='output/links_deprecated_ids.json', help="Default: 'output/links_deprecated_ids.json'")
+@click.option('-e', '--ext-ids', type=click.File('w'), default='output/external_ids_to_be_added.tsv', help="Default: 'output/external_ids_to_be_added.tsv'")
+@click.option('-u', '--urls', type=click.File('w'), default='output/urls_to_be_added.tsv', help="Default: 'output/urls_to_be_added.tsv'")
+@click.option('-w', '--wikidata', type=click.File('w'), default='output/wikidata_links.json', help="Default: 'output/wikidata_links.json'")
+def check_links_cli(entity, catalog, wikidata_dump, upload, sandbox, cache, deprecated, ext_ids, urls, wikidata):
     """Check the validity of identifier statements based on the available links.
 
-    Dump 3 files:
-    - catalog identifiers to be deprecated, as a JSON ``{identifer: QID}``;
-    - external identifiers to be added, as a TSV ``QID  identifier_PID  identifier``;
-    - URLs to be added, as a TSV ``QID  P973   URL``.
+    Dump 3 output files:
+
+    1. catalog identifiers to be deprecated, as a JSON ``{identifier: [QIDs]}``;
+
+    2. external identifiers to be added, as a TSV ``QID  identifier_PID  identifier``;
+
+    3. URLs to be added, as a TSV ``QID  P973   URL``.
     """
-    to_deprecate, ext_ids_to_add, urls_to_add, wikidata = check_links(
-        entity, catalog)
+    if cache is None:
+        to_deprecate, ext_ids_to_add, urls_to_add, wikidata_links = check_links(
+            entity, catalog)
+    else:
+        wikidata_cache = _load_wikidata_cache(cache)
+        to_deprecate, ext_ids_to_add, urls_to_add, wikidata_links = check_links(
+            entity, catalog, wikidata_cache)
 
     if wikidata_dump:
         json.dump({qid: {data_type: list(values) for data_type, values in data.items()}
-                   for qid, data in wikidata.items()}, wikidata_outfile, indent=2, ensure_ascii=False)
-        LOGGER.info('Wikidata links dumped to %s', wikidata_outfile.name)
+                   for qid, data in wikidata_links.items()}, wikidata, indent=2, ensure_ascii=False)
+        LOGGER.info('Wikidata links dumped to %s', wikidata.name)
     if upload:
-        upload_links(to_deprecate, ext_ids_to_add,
-                     urls_to_add, catalog, sandbox)
+        _upload_links(catalog, to_deprecate, urls_to_add,
+                      ext_ids_to_add, sandbox)
 
     json.dump({target_id: list(qids) for target_id,
-               qids in to_deprecate.items()}, deprecated_outfile, indent=2)
-    ext_ids_outfile.writelines(
+               qids in to_deprecate.items()}, deprecated, indent=2)
+    ext_ids.writelines(
         ['\t'.join(triple) + '\n' for triple in ext_ids_to_add])
-    urls_outfile.writelines(
+    urls.writelines(
         ['\t'.join(triple) + '\n' for triple in urls_to_add])
-    LOGGER.info('Result dumped to %s, %s, %s', deprecated_outfile.name,
-                ext_ids_outfile.name, urls_outfile.name)
+    LOGGER.info('Result dumped to %s, %s, %s', deprecated.name,
+                ext_ids.name, urls.name)
 
 
-def check_links(entity, catalog):
+def check_links(entity, catalog, wikidata_cache=None):
     catalog_terms = _get_vocabulary(catalog)
 
-    wikidata_links = {}
+    # Target links
+    target = _gather_target_links(entity, catalog)
+    # Early stop in case of no target links
+    if target is None:
+        return None, None, None
+
     to_deprecate = defaultdict(set)
     to_add = defaultdict(set)
 
-    # Target links
-    target_links = _gather_target_links(entity, catalog)
+    if wikidata_cache is None:
+        wikidata = {}
 
-    # Wikidata links
-    _gather_identifiers(entity, catalog, catalog_terms['pid'], wikidata_links)
-    url_pids, ext_id_pids_to_urls = _gather_relevant_pids()
-    _gather_wikidata_links(wikidata_links, url_pids, ext_id_pids_to_urls)
+        # Wikidata links
+        _gather_identifiers(entity, catalog, catalog_terms['pid'], wikidata)
+        url_pids, ext_id_pids_to_urls = _gather_relevant_pids()
+        _gather_wikidata_links(wikidata, url_pids, ext_id_pids_to_urls)
+    else:
+        wikidata = wikidata_cache
 
     # Check
-    _assess(wikidata_links, target_links, to_deprecate, to_add)
+    _assess('links', wikidata, target, to_deprecate, to_add)
 
     # Separate external IDs from URLs
     ext_ids_to_add, urls_to_add = _extract_ids_from_urls(
         to_add, ext_id_pids_to_urls)
 
-    LOGGER.info('Check completed. %d %s IDs to be deprecated, %d external IDs to be added, %d URL statements to be added', len(
+    LOGGER.info('Validation completed. %d %s IDs to be deprecated, %d external IDs to be added, %d URL statements to be added', len(
         to_deprecate), catalog, len(ext_ids_to_add), len(urls_to_add))
 
-    return to_deprecate, ext_ids_to_add, urls_to_add, wikidata_links
+    return to_deprecate, ext_ids_to_add, urls_to_add, wikidata
 
 
 @click.command()
 @click.argument('entity', type=click.Choice(HANDLED_ENTITIES.keys()))
 @click.argument('catalog', type=click.Choice(TARGET_CATALOGS.keys()))
-@click.option('--wikidata-dump/--no-wikidata-dump', default=False, help='Dump metadata gathered from Wikidata')
-@click.option('--upload/--no-upload', default=True, help='Upload check results to Wikidata')
-@click.option('--sandbox/--no-sandbox', default=False, help='Upload to the Wikidata sandbox item Q4115189')
-@click.option('-d', '--deprecated-outfile', type=click.File('w'), default='output/deprecated_ids.json', help="default: 'output/deprecated_ids.json'")
-@click.option('-a', '--added-outfile', type=click.File('w'), default='output/statements_to_be_added.tsv', help="default: 'output/statements_to_be_added.tsv'")
-@click.option('-w', '--wikidata-outfile', type=click.File('w'), default='output/wikidata_metadata.json', help="default: 'output/wikidata_metadata.json'")
-def check_metadata_cli(entity, catalog, wikidata_dump, upload, sandbox, deprecated_outfile, added_outfile, wikidata_outfile):
-    to_deprecate, to_add, wikidata = check_metadata(
-        entity, catalog)
+@click.option('--wikidata-dump/--no-wikidata-dump', default=False, help='Dump metadata gathered from Wikidata. Default: no.')
+@click.option('--upload/--no-upload', default=True, help='Upload check results to Wikidata. Default: yes.')
+@click.option('--sandbox/--no-sandbox', default=False, help='Upload to the Wikidata sandbox item Q4115189. Default: no.')
+@click.option('-c', '--cache', type=click.File(), default=None, help="Load Wikidata metadata previously dumped via '-w'. Default: no.")
+@click.option('-d', '--deprecated', type=click.File('w'), default='output/metadata_deprecated_ids.json', help="Default: 'output/metadata_deprecated_ids.json'")
+@click.option('-a', '--added', type=click.File('w'), default='output/statements_to_be_added.tsv', help="Default: 'output/statements_to_be_added.tsv'")
+@click.option('-w', '--wikidata', type=click.File('w'), default='output/wikidata_metadata.json', help="Default: 'output/wikidata_metadata.json'")
+def check_metadata_cli(entity, catalog, wikidata_dump, upload, sandbox, cache, deprecated, added, wikidata):
+    """Check the validity of identifier statements based on the availability
+    of the following metadata: birth/death date, birth/death place, gender.
 
-    if wikidata_dump and wikidata:
+    Dump 2 output files:
+
+    1. catalog identifiers to be deprecated, as a JSON ``{identifier: [QIDs]}``;
+
+    2. statements to be added, as a TSV ``QID  metadata_PID  value``;
+    """
+    if cache:
+        wikidata_cache = _load_wikidata_cache(cache)
+        to_deprecate, to_add, wikidata_metadata = check_metadata(
+            entity, catalog, wikidata_cache)
+    else:
+        to_deprecate, to_add, wikidata_metadata = check_metadata(
+            entity, catalog)
+
+    if wikidata_dump:
         json.dump({qid: {data_type: list(values) for data_type, values in data.items()}
-                   for qid, data in wikidata.items()}, wikidata_outfile, indent=2, ensure_ascii=False)
-        LOGGER.info('Wikidata metadata dumped to %s', wikidata_outfile.name)
+                   for qid, data in wikidata_metadata.items()}, wikidata, indent=2, ensure_ascii=False)
+        LOGGER.info('Wikidata metadata dumped to %s', wikidata.name)
     if upload:
-        # TODO upload_metadata(to_deprecate, to_add, catalog, sandbox)
-        pass
+        _upload(catalog, to_deprecate, to_add, sandbox)
 
     if to_deprecate:
         json.dump({target_id: list(qids) for target_id,
-                   qids in to_deprecate.items()}, deprecated_outfile, indent=2)
+                   qids in to_deprecate.items()}, deprecated, indent=2)
     if to_add:
-        added_outfile.writelines(
+        added.writelines(
             ['\t'.join(triple) + '\n' for triple in to_add])
 
     LOGGER.info('Result dumped to %s, %s',
-                deprecated_outfile.name, added_outfile.name)
+                deprecated.name, added.name)
 
 
-def check_metadata(entity, catalog):
+def check_metadata(entity, catalog, wikidata_cache=None):
     catalog_terms = _get_vocabulary(catalog)
+
+    # Target metadata
+    target = _gather_target_metadata(entity, catalog)
+    # Early stop in case of no target metadata
+    if target is None:
+        return None, None, None
 
     to_deprecate = defaultdict(set)
     to_add = defaultdict(set)
-    wikidata_meta = {}
 
-    # Target metadata
-    target_metadata = _gather_target_metadata(entity, catalog)
-    for row in target_metadata:
-        if row is None:
-            return to_deprecate, to_add, wikidata_meta
+    if wikidata_cache is None:
+        wikidata = {}
 
-    # Wikidata metadata
-    _gather_identifiers(entity, catalog, catalog_terms['pid'], wikidata_meta)
-    # TODO _gather_wikidata_meta(wikidata_meta)
+        # Wikidata metadata
+        _gather_identifiers(entity, catalog, catalog_terms['pid'], wikidata)
+        _gather_wikidata_metadata(wikidata)
+    else:
+        wikidata = wikidata_cache
 
     # Check
-    # TODO _assess(wikidata_meta, target_meta, to_deprecate, to_add)
+    _assess('metadata', wikidata, target, to_deprecate, to_add)
 
-    return to_deprecate, to_add, wikidata_meta
+    return to_deprecate, to_add, wikidata
 
 
+def _load_wikidata_cache(file_handle):
+    raw_cache = json.load(file_handle)
+    LOGGER.info("Loaded Wikidata cache from '%s'", file_handle.name)
+    cache = {}
+    for qid, data in raw_cache.items():
+        for data_type, value_list in data.items():
+            # Metadata has values that are a list
+            if isinstance(value_list[0], list):
+                value_set = set()
+                for value in value_list:
+                    value_set.add(tuple(value))
+                if cache.get(qid):
+                    cache[qid][data_type] = value_set
+                else:
+                    cache[qid] = {data_type: value_set}
+            else:
+                if cache.get(qid):
+                    cache[qid][data_type] = set(value_list)
+                else:
+                    cache[qid] = {data_type: set(value_list)}
+    return cache
+
+
+@cached
 def _gather_target_metadata(entity_type, catalog):
     catalog_constants = _get_catalog_constants(catalog)
     catalog_entity = _get_catalog_entity(entity_type, catalog_constants)
 
-    LOGGER.info('Gathering %s metadata ...', catalog)
+    LOGGER.info(
+        'Gathering %s birth/death dates/places and gender metadata ...', catalog)
     entity = catalog_entity['entity']
+    # Base metadata
+    query_fields = _build_metadata_query_fields(entity, entity_type, catalog)
+
+    session = _connect_to_db()
+    result = None
+    try:
+        result = _run_metadata_query(
+            session, query_fields, entity, catalog, entity_type)
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    if not result:
+        return None
+    return _parse_target_metadata_query_result(result)
+
+
+def _run_metadata_query(session, query_fields, entity, catalog, entity_type):
+    query = session.query(
+        *query_fields).filter(or_(entity.born.isnot(None), entity.died.isnot(None)))
+    count = query.count()
+    if count == 0:
+        LOGGER.warning(
+            "No metadata available for %s %s. Stopping validation here", catalog, entity_type)
+        return None
+    LOGGER.info('Got %d entries with metadata from %s %s',
+                count, catalog, entity_type)
+    result_set = query.all()
+    return result_set
+
+
+def _build_metadata_query_fields(entity, entity_type, catalog):
     # Base metadata
     query_fields = [entity.catalog_id, entity.born,
                     entity.born_precision, entity.died, entity.died_precision]
-    # Check additional metadata ('gender', 'birth_place', 'death_place'):
+    # Check additional metadata
     if hasattr(entity, 'gender'):
         query_fields.append(entity.gender)
     else:
@@ -227,35 +322,71 @@ def _gather_target_metadata(entity_type, catalog):
     else:
         LOGGER.info('%s %s has no death place information',
                     catalog, entity_type)
-    session = _connect_to_db()
-    query = session.query(
-        *query_fields).filter(or_(entity.born.isnot(None), entity.died.isnot(None)))
-    count = query.count()
-    if count == 0:
-        LOGGER.warning(
-            "No validation metadata available for %s. Stopping here", catalog)
-        yield None
-    LOGGER.info('Got %d metadata rows from %s', count, catalog)
-    for row in query.all():
-        yield row
+    return query_fields
 
 
-def _gather_target_links(entity, catalog):
+# Default date precision when not available: 9 (year)
+def _parse_target_metadata_query_result(result_set):
+    for result in result_set:
+        identifier = result.catalog_id
+        born = result.born
+        if born:
+            born_precision = getattr(result, 'born_precision', 9)
+            date_of_birth = f'{born}/{born_precision}'
+            yield identifier, vocabulary.DATE_OF_BIRTH, date_of_birth
+        else:
+            LOGGER.debug('%s: no birth date available', identifier)
+        died = result.died
+        if died:
+            died_precision = getattr(result, 'died_precision', 9)
+            date_of_death = f'{died}/{died_precision}'
+            yield identifier, vocabulary.DATE_OF_DEATH, date_of_death
+        else:
+            LOGGER.debug('%s: no death date available', identifier)
+        if hasattr(result, 'gender'):
+            yield identifier, vocabulary.SEX_OR_GENDER, result.gender
+        else:
+            LOGGER.debug('%s: no gender available', identifier)
+        if hasattr(result, 'birth_place'):
+            yield identifier, vocabulary.PLACE_OF_BIRTH, result.birth_place
+        else:
+            LOGGER.debug('%s: no birth place available', identifier)
+        if hasattr(result, 'death_place'):
+            yield identifier, vocabulary.PLACE_OF_DEATH, result.death_place
+        else:
+            LOGGER.debug('%s: no death place available', identifier)
+
+
+@cached
+def _gather_target_links(entity_type, catalog):
     catalog_constants = _get_catalog_constants(catalog)
-    catalog_entity = _get_catalog_entity(entity, catalog_constants)
+    catalog_entity = _get_catalog_entity(entity_type, catalog_constants)
 
-    LOGGER.info('Gathering %s links ...', catalog)
-    target_links = defaultdict(list)
-    count = 0
+    LOGGER.info('Gathering %s %s links ...', catalog, entity_type)
     link_entity = catalog_entity['link_entity']
+
     session = _connect_to_db()
-    result = session.query(link_entity.catalog_id, link_entity.url).all()
+    result = None
+    try:
+        query = session.query(link_entity.catalog_id, link_entity.url)
+        count = query.count()
+        if count == 0:
+            LOGGER.warning(
+                "No links available for %s %s. Stopping validation here", catalog, entity_type)
+            return None
+        LOGGER.info('Got %d links from %s %s', count, catalog, entity_type)
+        result = query.all()
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    if result is None:
+        return None
     for row in result:
-        target_links[row.catalog_id].append(row.url)
-        count += 1
-    LOGGER.info('Got %d links from %d %s identifiers',
-                count, len(target_links), catalog)
-    return target_links
+        yield row.catalog_id, row.url
 
 
 def _get_catalog_entity(entity, catalog_constants):
@@ -266,37 +397,52 @@ def _get_catalog_entity(entity, catalog_constants):
     return catalog_entity
 
 
-def _assess(source, target, to_deprecate, to_add):
-    LOGGER.info('Starting check against target links ...')
+def _assess(criterion, source, target_iterator, to_deprecate, to_add):
+    LOGGER.info('Starting check against target %s ...', criterion)
+    target = _consume_target_iterator(target_iterator)
+    # Large loop size = # given Wikidata class instances with identifiers, e.g., 80k musicians
     for qid, data in source.items():
-        identifiers = data['identifiers']
-        source_links = data.get('links')
-        if not source_links:
-            LOGGER.warning('Skipping check: no links available in QID %s', qid)
+        source_data = data.get(criterion)
+        if not source_data:
+            LOGGER.warning(
+                'Skipping check: no %s available in QID %s', criterion, qid)
             continue
+        identifiers = data['identifiers']
+        # 1 or tiny loop size = # of identifiers per Wikidata item (should always be 1)
         for target_id in identifiers:
             if target_id in target.keys():
-                target_links = target.get(target_id)
-                if not target_links:
+                target_data = target.get(target_id)
+                if not target_data:
                     LOGGER.warning(
-                        'Skipping check: no links available in target ID %s', target_id)
+                        'Skipping check: no %s available in target ID %s', criterion, target_id)
                     continue
-                target_links = set(target_links)
-                shared_links = source_links.intersection(target_links)
-                extra_links = target_links.difference(source_links)
-                if not shared_links:
+                shared = source_data.intersection(target_data)
+                extra = target_data.difference(source_data)
+                if not shared:
                     LOGGER.debug(
-                        'No shared links between %s and %s. The identifier statement will be deprecated', qid, target_id)
+                        'No shared %s between %s and %s. The identifier statement will be deprecated', criterion, qid, target_id)
                     to_deprecate[target_id].add(qid)
                 else:
-                    LOGGER.debug('%s and %s share these links: %s',
-                                 qid, target_id, shared_links)
-                if extra_links:
+                    LOGGER.debug('%s and %s share these %s: %s',
+                                 qid, target_id, criterion, shared)
+                if extra:
                     LOGGER.debug(
-                        '%s has extra links that will be added to %s: %s', target_id, qid, extra_links)
-                    to_add[qid].update(extra_links)
+                        '%s has extra %s that will be added to %s: %s', target_id, criterion, qid, extra)
+                    to_add[qid].update(extra)
                 else:
-                    LOGGER.debug('%s has no extra links', target_id)
+                    LOGGER.debug('%s has no extra %s', target_id, criterion)
+    LOGGER.info('Check against target %s completed: %d IDs to be deprecated, %d statements to be added',
+                criterion, len(to_deprecate), len(to_add))
+
+
+def _consume_target_iterator(target_iterator):
+    target = defaultdict(set)
+    for identifier, *data in target_iterator:
+        if len(data) == 1:  # Links
+            target[identifier].add(data.pop())
+        else:  # Metadata
+            target[identifier].add(tuple(data))
+    return target
 
 
 def _extract_ids_from_urls(to_add, ext_id_pids_to_urls):
@@ -331,12 +477,40 @@ def _get_catalog_constants(catalog):
     return catalog_constants
 
 
+def _gather_wikidata_metadata(wikidata):
+    LOGGER.info(
+        'Gathering Wikidata birth/death dates/places and gender metadata. This will take a while ...')
+    total = 0
+    # Generator of generators
+    for entity in api_requests.get_metadata(wikidata.keys()):
+        for qid, pid, value in entity:
+            parsed = _parse_wikidata_metadata_value(value)
+            if not wikidata[qid].get('metadata'):
+                wikidata[qid]['metadata'] = set()
+            wikidata[qid]['metadata'].add((pid, parsed))
+            total += 1
+    LOGGER.info('Got %d statements', total)
+
+
+def _parse_wikidata_metadata_value(value):
+    # Values: birth/death DATES, gender, birth/death places QIDs
+    date_value = value.get('time')
+    if date_value:
+        # +1180-01-01T00:00:00Z -> 1180-01-01
+        parsed = date_value[1:].split('T')[0]
+        return f"{parsed}/{value['precision']}"  # Date
+    item_value = value.get('id')
+    if item_value:
+        return item_value  # QID
+    return value  # String
+
+
 def _gather_wikidata_links(wikidata, url_pids, ext_id_pids_to_urls):
     LOGGER.info(
         'Gathering Wikidata sitelinks, third-party links, and external identifier links. This will take a while ...')
     total = 0
-    for result in api_requests.get_links(wikidata.keys(), url_pids, ext_id_pids_to_urls):
-        for qid, url in result.items():
+    for iterator in api_requests.get_links(wikidata.keys(), url_pids, ext_id_pids_to_urls):
+        for qid, url in iterator:
             if not wikidata[qid].get('links'):
                 wikidata[qid]['links'] = set()
             wikidata[qid]['links'].add(url)
@@ -367,7 +541,7 @@ def _gather_relevant_pids():
 
 def _gather_identifiers(entity, catalog, catalog_pid, aggregated):
     catalog_constants = _get_catalog_constants(catalog)
-    LOGGER.info('Gathering %s identifiers ...', catalog)
+    LOGGER.info('Gathering Wikidata items with %s identifiers ...', catalog)
     query_type = 'identifier', HANDLED_ENTITIES.get(entity)
     for result in sparql_queries.run_identifier_or_links_query(query_type, catalog_constants[entity]['qid'], catalog_pid, 0):
         for qid, target_id in result.items():
@@ -377,13 +551,18 @@ def _gather_identifiers(entity, catalog, catalog_pid, aggregated):
     LOGGER.info('Got %d %s identifiers', len(aggregated), catalog)
 
 
-def upload_links(to_deprecate, ext_ids_to_add, urls_to_add, catalog, sandbox):
+def _upload_links(catalog, to_deprecate, urls_to_add, ext_ids_to_add, sandbox):
+    catalog_qid = _upload(catalog, to_deprecate, urls_to_add, sandbox)
+    LOGGER.info('Starting addition of external IDs to Wikidata ...')
+    wikidata_bot.add_statements(ext_ids_to_add, catalog_qid, sandbox)
+
+
+def _upload(catalog, to_deprecate, to_add, sandbox):
     catalog_terms = _get_vocabulary(catalog)
     catalog_qid = catalog_terms['qid']
     LOGGER.info('Starting deprecation of %s IDs ...', catalog)
     wikidata_bot.delete_or_deprecate_identifiers(
         'deprecate', to_deprecate, catalog, sandbox)
-    LOGGER.info('Starting addition of external IDs to Wikidata ...')
-    wikidata_bot.add_statements(ext_ids_to_add, catalog_qid, sandbox)
-    LOGGER.info('Starting addition of URL statements to Wikidata ...')
-    wikidata_bot.add_statements(urls_to_add, catalog_qid, sandbox)
+    LOGGER.info('Starting addition of statements to Wikidata ...')
+    wikidata_bot.add_statements(to_add, catalog_qid, sandbox)
+    return catalog_qid

--- a/soweego/wikidata/vocabulary.py
+++ b/soweego/wikidata/vocabulary.py
@@ -66,7 +66,7 @@ CATALOG_MAPPING = {
     }
 }
 
-# Properties IDs with URL data type, from SPARQL query:
+# Properties with URL data type, from SPARQL query:
 # SELECT ?property WHERE { ?property a wikibase:Property ; wikibase:propertyType wikibase:Url . }
 URL_PIDS = set([
     'P854', 'P855', 'P856', 'P953', 'P963', 'P968', 'P973', 'P1019', 'P1065',
@@ -76,3 +76,12 @@ URL_PIDS = set([
     'P3268', 'P3950', 'P4001', 'P4238', 'P4570', 'P4656', 'P4765', 'P4945',
     'P4997', 'P5178', 'P5195', 'P5282', 'P5305', 'P5715'
 ])
+
+# Properties for metadata-based validation: gender, birth/death date/place
+PLACE_OF_BIRTH = 'P19'
+PLACE_OF_DEATH = 'P20'
+SEX_OR_GENDER = 'P21'
+DATE_OF_BIRTH = 'P569'
+DATE_OF_DEATH = 'P570'
+METADATA_PIDS = set([PLACE_OF_BIRTH, PLACE_OF_DEATH,
+                     SEX_OR_GENDER, DATE_OF_BIRTH, DATE_OF_DEATH])


### PR DESCRIPTION
- Better CLIs for links and metadata validation;
- early stop validation when no target data is available;
- optional Wikidata cache to avoid API calls during development;
- general-purpose caching facility;
- cache target data;
- normalize Wikidata and target metadata for comparison;
- try to use generators when possible;
- refactor.