### PR TITLE
Make importers use bulk insert functionality for DB

### DIFF
--- a/soweego/importer/discogs_dump_extractor.py
+++ b/soweego/importer/discogs_dump_extractor.py
@@ -42,7 +42,7 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
     valid_links = 0
     dead_links = 0
 
-    _sqlalchemy_commit_every = 700
+    _sqlalchemy_commit_every = 5000
 
     def get_dump_download_urls(self) -> Iterable[str]:
         response = get(DUMP_LIST_URL_TEMPLATE.format(date.today().year))
@@ -90,7 +90,7 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
             # we count how many iterations we've done up until now
             # so that we can do an insertion every `self._sqlalchemy_commit_every`
             # loops
-            e_counter = 0
+            e_counter = 1
 
             for _, node in tqdm(et.iterparse(dump), total=n_rows):
                 if not node.tag == 'artist':
@@ -137,6 +137,7 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
                 if e_counter % self._sqlalchemy_commit_every == 0:
                     # commit in batches of `self._sqlalchemy_commit_every`
                     session.commit()
+                    session.expunge_all()
 
                 e_counter += 1
 

--- a/soweego/importer/discogs_dump_extractor.py
+++ b/soweego/importer/discogs_dump_extractor.py
@@ -11,13 +11,16 @@ __copyright__ = 'Copyleft 2018, Hjfocs'
 
 import gzip
 import logging
+import os
+import shutil
 import xml.etree.ElementTree as et
 from datetime import date, datetime
-from typing import Iterable
+from typing import Iterable, Tuple
 
 from requests import get
 from tqdm import tqdm
 
+from lxml import etree
 from soweego.commons import text_utils, url_utils
 from soweego.commons.db_manager import DBManager
 from soweego.importer.base_dump_extractor import BaseDumpExtractor
@@ -55,7 +58,7 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
                 dump_file_name = child.text
         if dump_file_name is None:
             LOGGER.error(
-                "Failed to get the Discogs dump download URL: are we at the very start of the year?")
+                'Failed to get the Discogs dump download URL: are we at the very start of the year?')
             return None
         return [DUMP_BASE_URL + dump_file_name]
 
@@ -78,82 +81,109 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
         LOGGER.info('SQL tables dropped and re-created: %s',
                     [table.__tablename__ for table in tables])
 
-        with gzip.open(dump_file_path, 'rt') as dump:
+        extracted_path = '.'.join(dump_file_path.split('.')[:-1])
 
-            # count number of lines and move again up to the beginning
-            # of the file
-            n_rows = sum(1 for line in dump)
-            dump.seek(0)
+        # Extract dump file if it has not yet been extracted
+        if not os.path.exists(extracted_path):
 
-            session = db_manager.new_session()
+            LOGGER.info('Extracting dump file')
 
-            entity_array = []  # array to which we'll add the entities
+            with gzip.open(dump_file_path, 'rb') as f_in:
+                with open(extracted_path, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
 
-            for _, node in tqdm(et.iterparse(dump), total=n_rows):
-                if not node.tag == 'artist':
-                    continue
+        def g_process_et_items() -> Iterable[Tuple]:
+            """
+            Generator: Processes ElementTree items in a memory
+            efficient way
+            """
 
-                # Skip nodes without required fields
-                identifier = node.findtext('id')
-                if not identifier:
-                    LOGGER.warning(
-                        'Skipping import for artist node with no identifier: %s', node)
-                    continue
-                name = node.findtext('name')
-                if not name:
-                    LOGGER.warning(
-                        'Skipping import for identifier with no name: %s', identifier)
-                    continue
+            context: etree.ElementTree = etree.iterparse(
+                extracted_path,
+                events=('end',),
+                tag='artist')
 
-                living_links = self._extract_living_links(
-                    node, identifier, resolve)
+            for event, elem in context:
+                yield event, elem
 
-                # Musician
-                groups = node.find('groups')
-                members = node.find('members')
-                if groups:
-                    entity = discogs_entity.DiscogsMusicianEntity()
-                    self._populate_musician(entity_array,
-                                            entity, identifier, name, living_links, node)
-                # Band
-                elif members:
-                    entity = discogs_entity.DiscogsGroupEntity()
-                    self._populate_band(entity_array, entity, identifier,
-                                        name, living_links, node)
-                # Can't infer the entity type, so populate both
-                else:
-                    LOGGER.debug(
-                        'Unknown artist type. Will add it to both musicians and bands: %s', identifier)
-                    entity = discogs_entity.DiscogsMusicianEntity()
-                    self._populate_musician(entity_array,
-                                            entity, identifier, name, living_links, node)
-                    entity = discogs_entity.DiscogsGroupEntity()
-                    self._populate_band(entity_array, entity, identifier,
-                                        name, living_links, node)
+                # delete content of node once we're done processing
+                # it. If we don't then it would stay in memory
+                elem.clear()
 
-                # commit in batches of `self._sqlalchemy_commit_every`
-                if len(entity_array) > self._sqlalchemy_commit_every:
+        # count number of entries
+        n_rows = sum(1 for _ in g_process_et_items())
 
-                    LOGGER.info("Adding batch of entities to the database, this might take a couple of minutes. "
-                                "Progress will resume soon.")
+        session = db_manager.new_session()
 
-                    insert_start_time = datetime.now()
+        entity_array = []  # array to which we'll add the entities
 
-                    session.bulk_save_objects(entity_array)
-                    session.commit()
-                    session.expunge_all()  # clear session
+        for _, node in tqdm(g_process_et_items(), total=n_rows):
 
-                    entity_array.clear()  # clear entity array
+            if not node.tag == 'artist':
+                continue
 
-                    LOGGER.debug("It took %s to add %s entities to the database",
-                                 datetime.now()-insert_start_time,
-                                 self._sqlalchemy_commit_every)
+            # Skip nodes without required fields
+            identifier = node.findtext('id')
+            if not identifier:
+                LOGGER.warning(
+                    'Skipping import for artist node with no identifier: %s', node)
+                continue
 
-            # finally commit remaining entities in session
-            # (if any), and close session
-            session.bulk_save_objects(entity_array)
-            session.commit()
-            session.close()
+            name = node.findtext('name')
+            if not name:
+                LOGGER.warning(
+                    'Skipping import for identifier with no name: %s', identifier)
+                continue
+
+            living_links = self._extract_living_links(
+                node, identifier, resolve)
+
+            # Musician
+            groups = node.find('groups')
+            members = node.find('members')
+            if groups:
+                entity = discogs_entity.DiscogsMusicianEntity()
+                self._populate_musician(entity_array,
+                                        entity, identifier, name, living_links, node)
+            # Band
+            elif members:
+                entity = discogs_entity.DiscogsGroupEntity()
+                self._populate_band(entity_array, entity, identifier,
+                                    name, living_links, node)
+            # Can't infer the entity type, so populate both
+            else:
+                LOGGER.debug(
+                    'Unknown artist type. Will add it to both musicians and bands: %s', identifier)
+                entity = discogs_entity.DiscogsMusicianEntity()
+                self._populate_musician(entity_array,
+                                        entity, identifier, name, living_links, node)
+                entity = discogs_entity.DiscogsGroupEntity()
+                self._populate_band(entity_array, entity, identifier,
+                                    name, living_links, node)
+
+            # commit in batches of `self._sqlalchemy_commit_every`
+            if len(entity_array) >= self._sqlalchemy_commit_every:
+
+                LOGGER.info('Adding batch of entities to the database, this might take a couple of minutes. '
+                            'Progress will resume soon.')
+
+                insert_start_time = datetime.now()
+
+                session.bulk_save_objects(entity_array)
+                session.commit()
+                session.expunge_all()  # clear session
+
+                entity_array.clear()  # clear entity array
+
+                LOGGER.debug('It took %s to add %s entities to the database',
+                             datetime.now()-insert_start_time,
+                             self._sqlalchemy_commit_every)
+
+        # finally commit remaining entities in session
+        # (if any), and close session
+        session.bulk_save_objects(entity_array)
+        session.commit()
+        session.close()
 
         end = datetime.now()
         LOGGER.info(

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -42,7 +42,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
     n_misc = 0
     n_person_movie_links = 0
 
-    _sqlalchemy_commit_every = 2_000_000
+    _sqlalchemy_commit_every = 1_500_000
 
     def get_dump_download_urls(self) -> List[str]:
         """

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -71,7 +71,9 @@ class ImdbDumpExtractor(BaseDumpExtractor):
     def extract_and_populate(self, dump_file_paths: List[str], resolve: bool) -> None:
         """
         Extracts the data in the dumps (person and movie) and processes them.
-        It then proceeds to add the appropriate data to the database. See
+        It then proceeds to add the appropriate data to the database. 
+        
+        See
         :ref:`soweego.importer.models.imdb_entity` module to see the SQLAlchemy
         definition of the entities we use to save IMDB data.
 
@@ -225,8 +227,8 @@ class ImdbDumpExtractor(BaseDumpExtractor):
 
     def _loop_through_entities(self, file_path: str) -> Generator[Tuple[Dict, List], None, None]:
         """
-        Generator that given an IMDb dump file (which 
-        should be ".tsv.gz" format) it loops through every 
+        Generator that given an IMDb dump file (which
+        should be ".tsv.gz" format) it loops through every
         entry and yields it.
 
         :return: a generator which yields a Tuple[entity_info, entity_array]
@@ -347,7 +349,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
         in IMDB and the IDs of the movies for which this person is
         known (which also come from IMDB). We add a
         :ref:`soweego.importer.models.imdb_entity.ImdbPersonMovieRelationship`
-        entity to the session for each realtion.
+        entity to the session for each relation.
 
         :param person_info: dictionary that contains the IMDB person ID and
         the IMDB movie IDs (for movies the specific person is known). The movie

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -270,7 +270,8 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                 # is done
                 if e_counter % self._sqlalchemy_commit_every == 0:
 
-                    LOGGER.info("Adding entities to the database, this might take a couple of minutes.")
+                    LOGGER.info("Adding entities to the database, this might take a couple of minutes. "
+                    "Progress will resume soon.")
                     
                     sss = datetime.datetime.now()
 
@@ -280,7 +281,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
 
                     entity_array.clear() # clear entity array
                     
-                    LOGGER.debug("It took %s to entities to the database", datetime.datetime.now()-sss)
+                    LOGGER.debug("It took %s to add the entities to the database", datetime.datetime.now()-sss)
 
                 e_counter += 1
 

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -261,8 +261,8 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                 # is done
                 if len(entity_array) >= self._sqlalchemy_commit_every:
 
-                    LOGGER.info("Adding batch of entities to the database, this might take a couple of minutes. "
-                                "Progress will resume soon.")
+                    LOGGER.info('Adding batch of entities to the database, this might take a couple of minutes. '
+                                'Progress will resume soon.')
 
                     insert_start_time = datetime.datetime.now()
 
@@ -272,7 +272,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
 
                     entity_array.clear()  # clear entity array
 
-                    LOGGER.debug("It took %s to add %s entities to the database",
+                    LOGGER.debug('It took %s to add %s entities to the database',
                                  datetime.datetime.now()-insert_start_time,
                                  len(entity_array))
 

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -289,6 +289,10 @@ class ImdbDumpExtractor(BaseDumpExtractor):
             session.bulk_save_objects(entity_array)
             session.commit()
 
+            # clear list reference since it might still be available in
+            # the scope where this generator was used.
+            entity_array.clear() 
+
     def _populate_person(self, person_entity: imdb_entity.ImdbPersonEntity,
                          person_info: Dict,
                          entity_array: object) -> None:

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -253,7 +253,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
 
             # counter to see how often we need to commit the session to
             # the DB
-            e_counter = 0
+            e_counter = 1
 
             # for every entry in the file..
             for entity_info in tqdm(reader, total=n_rows):

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -268,7 +268,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                     LOGGER.info("Adding batch of entities to the database, this might take a couple of minutes. "
                                 "Progress will resume soon.")
 
-                    sss = datetime.datetime.now()
+                    insert_start_time = datetime.datetime.now()
 
                     session.bulk_save_objects(entity_array)
                     session.commit()
@@ -276,7 +276,8 @@ class ImdbDumpExtractor(BaseDumpExtractor):
 
                     entity_array.clear()  # clear entity array
 
-                    LOGGER.debug("It took %s to add %s entities to the database", datetime.datetime.now()-sss,
+                    LOGGER.debug("It took %s to add %s entities to the database",
+                                 datetime.datetime.now()-insert_start_time,
                                  self._sqlalchemy_commit_every)
 
                 e_counter += 1

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -270,7 +270,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                 # is done
                 if e_counter % self._sqlalchemy_commit_every == 0:
 
-                    LOGGER.info("Adding entities to the database, this might take a couple of minutes. "
+                    LOGGER.info("Adding batch of entities to the database, this might take a couple of minutes. "
                     "Progress will resume soon.")
                     
                     sss = datetime.datetime.now()
@@ -286,6 +286,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                 e_counter += 1
 
             # commit remaining entities
+            session.bulk_save_objects(entity_array)
             session.commit()
 
     def _populate_person(self, person_entity: imdb_entity.ImdbPersonEntity,

--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -72,7 +72,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
         """
         Extracts the data in the dumps (person and movie) and processes them.
         It then proceeds to add the appropriate data to the database. 
-        
+
         See
         :ref:`soweego.importer.models.imdb_entity` module to see the SQLAlchemy
         definition of the entities we use to save IMDB data.
@@ -111,7 +111,6 @@ class ImdbDumpExtractor(BaseDumpExtractor):
 
         LOGGER.info('Starting import of movies ...')
 
-
         # Here we open the movie dump file, and add everything to the DB
         for movie_info, entity_array in self._loop_through_entities(movies_file_path):
 
@@ -146,8 +145,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
         # reset timer for persons import
         start = datetime.datetime.now()
 
-        
-        for person_info, entity_array  in self._loop_through_entities(person_file_path):
+        for person_info, entity_array in self._loop_through_entities(person_file_path):
 
             # IMDb saves the list of professions as a comma separated
             # string
@@ -158,7 +156,6 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                 LOGGER.debug('Person %s has no professions',
                              person_info.get('nconst'))
                 continue
-
 
             professions = professions.split(',')
 
@@ -199,7 +196,6 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                     imdb_entity.ImdbProducerEntity(),
                     imdb_entity.ImdbWriterEntity(),
                 ]
-            
 
             # add person to every matching table
             for etype in types_of_entities:
@@ -213,7 +209,6 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                     person_info, entity_array)
 
             self.n_persons += 1
-
 
         # mark the end time for the person import process
         end = datetime.datetime.now()
@@ -271,17 +266,18 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                 if e_counter % self._sqlalchemy_commit_every == 0:
 
                     LOGGER.info("Adding batch of entities to the database, this might take a couple of minutes. "
-                    "Progress will resume soon.")
-                    
+                                "Progress will resume soon.")
+
                     sss = datetime.datetime.now()
 
                     session.bulk_save_objects(entity_array)
                     session.commit()
-                    session.expunge_all() # clear session
+                    session.expunge_all()  # clear session
 
-                    entity_array.clear() # clear entity array
-                    
-                    LOGGER.debug("It took %s to add the entities to the database", datetime.datetime.now()-sss)
+                    entity_array.clear()  # clear entity array
+
+                    LOGGER.debug("It took %s to add %s entities to the database", datetime.datetime.now()-sss,
+                                 self._sqlalchemy_commit_every)
 
                 e_counter += 1
 
@@ -291,7 +287,7 @@ class ImdbDumpExtractor(BaseDumpExtractor):
 
             # clear list reference since it might still be available in
             # the scope where this generator was used.
-            entity_array.clear() 
+            entity_array.clear()
 
     def _populate_person(self, person_entity: imdb_entity.ImdbPersonEntity,
                          person_info: Dict,
@@ -322,7 +318,6 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                for prof in ['actor', 'actress']):
             person_entity.gender = 'male' if 'actor' in person_info.get(
                 'primaryProfession') else 'female'
-
 
         # IMDb only provides us with the birth and death year of
         # a person, so this is the only one we'll take into

--- a/soweego/importer/musicbrainz_dump_extractor.py
+++ b/soweego/importer/musicbrainz_dump_extractor.py
@@ -39,7 +39,7 @@ LOGGER = logging.getLogger(__name__)
 
 class MusicBrainzDumpExtractor(BaseDumpExtractor):
 
-    _sqlalchemy_commit_every = 1_500_000
+    _sqlalchemy_commit_every = 1_000_000
 
     def get_dump_download_urls(self) -> Iterable[str]:
         latest_version = requests.get(
@@ -156,7 +156,7 @@ class MusicBrainzDumpExtractor(BaseDumpExtractor):
 
                 # commit entities to DB in batches, it is mode
                 # efficient
-                if n_added_entities+1 % self._sqlalchemy_commit_every == 0:
+                if len(entity_array) >= self._sqlalchemy_commit_every:
 
                     LOGGER.info("Adding batch of entities to the database, "
                                 "this might take a couple of minutes. Progress will "
@@ -172,7 +172,7 @@ class MusicBrainzDumpExtractor(BaseDumpExtractor):
 
                     LOGGER.debug("It took %s to add %s entities to the database",
                                  datetime.now()-insert_start_time,
-                                 self._sqlalchemy_commit_every)
+                                 len(entity_array))
 
                 n_added_entities += 1
 

--- a/soweego/importer/musicbrainz_dump_extractor.py
+++ b/soweego/importer/musicbrainz_dump_extractor.py
@@ -39,7 +39,7 @@ LOGGER = logging.getLogger(__name__)
 
 class MusicBrainzDumpExtractor(BaseDumpExtractor):
 
-    _sqlalchemy_commit_every = 700
+    _sqlalchemy_commit_every = 1_500_000
 
     def get_dump_download_urls(self) -> Iterable[str]:
         latest_version = requests.get(
@@ -120,7 +120,7 @@ class MusicBrainzDumpExtractor(BaseDumpExtractor):
                      *relationships_count)
 
     def _add_entities_from_generator(self, db_manager,
-                                     _generator, *args) -> Tuple[int, int]:
+                                     generator_, *args) -> Tuple[int, int]:
         """
         Adds all entities yielded by a generator to the DB
 
@@ -138,28 +138,43 @@ class MusicBrainzDumpExtractor(BaseDumpExtractor):
         session = db_manager.new_session()
 
         # we construct the generator
-        blt_gen = _generator(*args)
+        blt_gen = generator_(*args)
 
         # and obtain the first item, which is
         # the number of rows that the generator will yield
         n_rows = next(blt_gen)
 
+        entity_array = [] # array to which we'll add the entities
+
+        # the generator will give us a new entity each loop
+        # so we just add this to the `entity_array` and commit
+        # it once it is large enough (self._sqlalchemy_commit_every)
         for entity in tqdm(blt_gen, total=n_rows):
             try:
                 n_total_entities += 1
-                session.add(entity)
+                entity_array.append(entity)
 
                 # commit entities to DB in batches, it is mode
                 # efficient
                 if n_added_entities+1 % self._sqlalchemy_commit_every == 0:
-                    session.commit()
 
+                    LOGGER.info("Adding batch of entities to the database, "
+                    "this might take a couple of minutes. Progress will "
+                    "resume soon.")
+                    
+                    session.bulk_save_objects(entity_array)
+                    session.commit()
+                    session.expunge_all() # clear session
+
+                    entity_array.clear() # clear entity array
+                    
                 n_added_entities += 1
 
             except IntegrityError as i:
                 LOGGER.warning(str(i))
 
         # finally, commit remaining entities in session
+        session.bulk_save_objects(entity_array)
         session.commit()
 
         # and close session

--- a/soweego/importer/musicbrainz_dump_extractor.py
+++ b/soweego/importer/musicbrainz_dump_extractor.py
@@ -151,7 +151,7 @@ class MusicBrainzDumpExtractor(BaseDumpExtractor):
 
                 # commit entities to DB in batches, it is mode
                 # efficient
-                if n_added_entities % self._sqlalchemy_commit_every == 0:
+                if n_added_entities+1 % self._sqlalchemy_commit_every == 0:
                     session.commit()
 
                 n_added_entities += 1


### PR DESCRIPTION
`session.add(entity)` has been replaced with `session.bulk_save_objects(entity_array)` in all importers. 

Another change that was made was to the `discogs_dump_extractor.py` file: the previous method of reading the file occupied all the RAM, since nodes were kept in memory after reading. Now, each node is deleted after it is traversed. 

This closes #206 