### PR TITLE
Don't include occupation which is already implicit in table name when importing IMDb person

### DIFF
--- a/soweego/importer/imdb_dump_extractor.py
+++ b/soweego/importer/imdb_dump_extractor.py
@@ -276,7 +276,6 @@ class ImdbDumpExtractor(BaseDumpExtractor):
                                  datetime.datetime.now()-insert_start_time,
                                  len(entity_array))
 
-
             # commit remaining entities
             session.bulk_save_objects(entity_array)
             session.commit()
@@ -333,9 +332,17 @@ class ImdbDumpExtractor(BaseDumpExtractor):
         # The array of primary professions gets translated to a list
         # of the QIDs that represent said professions in Wikidata
         if person_info.get('primaryProfession'):
-            person_entity.occupations = ' '.join(self._translate_professions(
+
+            # get QIDs of occupations for person
+            translated_occupations = self._translate_professions(
                 person_info.get('primaryProfession').split(',')
-            ))
+            )
+
+            # only save those occupations which are not the main
+            # occupation of the entity type (ie, for ActorEntity
+            # don't include 'actor' occupation since it is implicit)
+            person_entity.occupations = ' '.join(
+                occ for occ in translated_occupations if occ != person_entity.table_occupation)
 
         entity_array.append(person_entity)
 

--- a/soweego/importer/models/imdb_entity.py
+++ b/soweego/importer/models/imdb_entity.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import relationship
 
 from soweego.importer.models.base_entity import BaseEntity, BaseRelationship
 from soweego.importer.models.base_link_entity import BaseLinkEntity
+from soweego.wikidata import vocabulary
 
 BASE = declarative_base()
 
@@ -55,6 +56,11 @@ class ImdbMovieEntity(BASE):
 
 
 class ImdbPersonEntity(BaseEntity):
+    # each table/entity type should be associated with
+    # an occupation (defined in vocabulary.py) which
+    # is the main occupation for people in said table
+    table_occupation = None
+
     __tablename__ = BASE_PERSON_TABLE
     __mapper_args__ = {
         'polymorphic_identity': __tablename__,
@@ -74,6 +80,8 @@ class ImdbPersonEntity(BaseEntity):
 
 
 class ImdbActorEntity(ImdbPersonEntity):
+    table_occupation = vocabulary.ACTOR
+
     __tablename__ = ACTOR_TABLE
     __mapper_args__ = {
         'polymorphic_identity': __tablename__,
@@ -81,6 +89,8 @@ class ImdbActorEntity(ImdbPersonEntity):
 
 
 class ImdbDirectorEntity(ImdbPersonEntity):
+    table_occupation = vocabulary.DIRECTOR
+    
     __tablename__ = DIRECTOR_TABLE
     __mapper_args__ = {
         'polymorphic_identity': __tablename__,
@@ -88,6 +98,8 @@ class ImdbDirectorEntity(ImdbPersonEntity):
 
 
 class ImdbMusicianEntity(ImdbPersonEntity):
+    table_occupation = vocabulary.MUSICIAN
+    
     __tablename__ = MUSICIAN_TABLE
     __mapper_args__ = {
         'polymorphic_identity': __tablename__,
@@ -95,6 +107,8 @@ class ImdbMusicianEntity(ImdbPersonEntity):
 
 
 class ImdbProducerEntity(ImdbPersonEntity):
+    table_occupation = vocabulary.FILM_PRODUCER
+    
     __tablename__ = PRODUCER_TABLE
     __mapper_args__ = {
         'polymorphic_identity': __tablename__,
@@ -102,6 +116,8 @@ class ImdbProducerEntity(ImdbPersonEntity):
 
 
 class ImdbWriterEntity(ImdbPersonEntity):
+    table_occupation = vocabulary.SCREENWRITER
+    
     __tablename__ = WRITER_TABLE
     __mapper_args__ = {
         'polymorphic_identity': __tablename__,


### PR DESCRIPTION
Since the occupation related to a specific table name (ie, Actor table) is already implicit then we don't want to include this as one of the occupations while importing IMDb entities.

I've added a new `table_occupation` field to each `ImdbPersonEntity` definition which specifies the main QID that stands for the occupation which the table represents. This field is then used in the importing process to filter out the unwanted QID. 

I did it this way (adding the field to each entity definition) so that it is straightforward to include new entities in the future, if needed.

Closes #232 