### PR TITLE
Delete extracted discogs dump after import

### DIFF
--- a/soweego/importer/discogs_dump_extractor.py
+++ b/soweego/importer/discogs_dump_extractor.py
@@ -191,6 +191,9 @@ class DiscogsDumpExtractor(BaseDumpExtractor):
             end - start, self.total_entities, self.musicians, self.musician_links, self.bands, self.band_links,
             self.dead_links)
 
+        # once the import process is complete, we can safely delete the extracted discogs dump
+        os.remove(extracted_path)
+
     def _populate_band(self, entity_array, entity: discogs_entity.DiscogsGroupEntity, identifier, name, links, node):
         # Main entity
         self._fill_entity(entity, identifier, name, node)


### PR DESCRIPTION
Once the import process is done, delete the extracted discogs dump, but leave the compressed version intact.

closes #241