### PR TITLE
Bot follows redirects when uploading data

### DIFF
--- a/soweego/ingestor/wikidata_bot.py
+++ b/soweego/ingestor/wikidata_bot.py
@@ -176,6 +176,12 @@ def delete_or_deprecate_identifiers(action: str, invalid: dict, catalog_name: st
 
 def _add_or_reference(subject: str, predicate: str, value: str, stated_in: str) -> None:
     item = pywikibot.ItemPage(REPO, subject)
+
+    # get redirect target recursively in case a redirect points
+    # to another redirect
+    while item.isRedirectPage():
+        item = item.getRedirectTarget()
+
     data = item.get()
     # No data at all
     if not data:


### PR DESCRIPTION
If a bot encounters an entity which is a redirect when uploading data then it will follow that redirect and add the data to the target of the redirect.

Redirects are followed _recursively_ so bot is also able to follow redirects which point to other redirects

closes #219