### PR TITLE
Fixed progress bar appearance 

### DIFF
--- a/soweego/commons/logging.py
+++ b/soweego/commons/logging.py
@@ -3,7 +3,6 @@
 # Adapted from https://github.com/Wikidata/StrepHit/blob/master/strephit/commons/logging.py
 
 """Logging facility"""
-import json
 
 __author__ = 'Marco Fossati'
 __email__ = 'fossati@spaziodati.eu'
@@ -11,11 +10,14 @@ __version__ = '1.0'
 __license__ = 'GPL-3.0'
 __copyright__ = 'Copyleft 2018, Hjfocs'
 
+import json
 import logging
 import logging.config
 import os
 from io import StringIO
 from urllib.parse import unquote_plus
+
+import tqdm
 
 LEVELS = {
     'DEBUG': logging.DEBUG,
@@ -46,7 +48,7 @@ DEFAULT_CONFIG = {
     'handlers': {
         'console': {
             'formatter': 'soweego',
-            'class': 'logging.StreamHandler',
+            'class': 'soweego.commons.logging.TqdmLoggingHandler',
             'level': 'INFO'
         },
         'debug_file_handler': {
@@ -59,6 +61,30 @@ DEFAULT_CONFIG = {
         }
     }
 }
+
+
+class TqdmLoggingHandler (logging.StreamHandler):
+    """
+    Custom logging handler. This ensures that TQDM
+    progress bars always stay at the bottom of the
+    terminal instead of being printed as normal
+    messages
+    """
+
+    def __init__(self, stream=None):
+        super().__init__(stream)
+
+    # we only overwrite `Logging.StreamHandler`
+    # emit method. Everything else is
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            tqdm.tqdm.write(msg)
+            self.flush()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)
 
 
 def setup():

--- a/soweego/commons/logging.py
+++ b/soweego/commons/logging.py
@@ -75,7 +75,7 @@ class TqdmLoggingHandler (logging.StreamHandler):
         super().__init__(stream)
 
     # we only overwrite `Logging.StreamHandler`
-    # emit method. Everything else is
+    # emit method 
     def emit(self, record):
         try:
             msg = self.format(record)


### PR DESCRIPTION
Progress bar no longer gets _pushed up_ when messages are printed using the logger: the bar now stays at the bottom of the terminal while new messages are printed on top of it. 

Another thing that this PR fixes is that now the progress bar no longer _disappears_ while importing the _musicbrainz_ dump. 

closes #244 