### PR TITLE
Clean up parallel-wikidata-download

### DIFF
--- a/soweego/wikidata/api_requests.py
+++ b/soweego/wikidata/api_requests.py
@@ -93,9 +93,12 @@ def _process_bucket(bucket, request_params, url_pids, ext_id_pids_to_urls, qids_
     wikidata to be processed in parallel.
     """
     response_body = _make_request(bucket, request_params)
-
+    
+    # If there is no response then
+    # we treat it as if there were no entities in
+    # the bucket, and return an empty list
     if not response_body:
-        return ''
+        return [] 
 
     # Each bucket is composed of different entities.
     # In this list we'll keep track of the results

--- a/soweego/wikidata/api_requests.py
+++ b/soweego/wikidata/api_requests.py
@@ -18,7 +18,7 @@ import pickle
 from collections import defaultdict
 from functools import lru_cache, partial
 from multiprocessing.pool import Pool
-from typing import Generator, TextIO
+from typing import Dict, Generator, List, TextIO
 from urllib.parse import urlunsplit
 
 import requests
@@ -86,7 +86,7 @@ def _lookup_label(item_value):
 def _process_bucket(bucket, request_params, url_pids, ext_id_pids_to_urls, qids_and_tids,
                     no_labels_count, no_aliases_count, no_descriptions_count,
                     no_sitelinks_count, no_links_count, no_ext_ids_count, no_claims_count,
-                    needs_occupations) -> str:
+                    needs_occupations) -> List[Dict]:
     """
     This function will be consumed by the `get_data_for_linker`
     function in this module. It allows the buckets coming from

--- a/soweego/wikidata/api_requests.py
+++ b/soweego/wikidata/api_requests.py
@@ -644,10 +644,8 @@ def _make_request(bucket, params):
     params['ids'] = '|'.join(bucket)
     connection_is_ok = True
 
-    oldC = get_authenticated_session()
-
     session = requests.Session()
-    session.cookies = oldC.cookies
+    session.cookies = get_authenticated_session().cookies
 
     while True:
         try:

--- a/soweego/wikidata/api_requests.py
+++ b/soweego/wikidata/api_requests.py
@@ -97,7 +97,7 @@ def _process_bucket(bucket, request_params, url_pids, ext_id_pids_to_urls, qids_
     if not response_body:
         return ''
 
-    # Each bucket is composed of of different entities.
+    # Each bucket is composed of different entities.
     # In this list we'll keep track of the results
     # when processing each of them
     bucket_results = []


### PR DESCRIPTION
The logic to process a wikidata bucket has been extracted to it's own method, `_process_bucket`. This is now called in a paralellized way by `get_data_for_linker` 

The function `_make_request` now creates a new `requests.Session` object each time it is created (the session will still be using the cookies of the _authenticated session_, so the bot and the request limits still work as expected). This was done to prevent all threads from using the same `Session` object, which would introduce a bottleneck

closes #257 