### PR TITLE
Don't stringify list values when preprocessing 

### DIFF
--- a/soweego/linker/feature_extraction.py
+++ b/soweego/linker/feature_extraction.py
@@ -314,8 +314,7 @@ class SimilarTokens(BaseCompareFeature):
                     "Can't compare Tokens, the pair contains null values: %s", pair)
                 return np.nan
 
-            source_labels = [pair[0]] if isinstance(pair[0], str) else pair[0]
-            target_labels = [pair[1]] if isinstance(pair[1], str) else pair[1]
+            source_labels, target_labels = pair
 
             first_set = set(source_labels)
             second_set = set()

--- a/soweego/linker/feature_extraction.py
+++ b/soweego/linker/feature_extraction.py
@@ -201,8 +201,8 @@ class DateCompare(BaseCompareFeature):
         
         def check_date_equality(pair: Tuple[List[pd.Period], List[pd.Period]]):
             """
-            Compares a target pd.Period with the source pd.Periods which represent either
-            a birth or death date. The source date can be a list of possible dates.
+            Compares the target pd.Periods with the source pd.Periods which represent either
+            a birth or death date.
 
             Returns the most optimistic match
             """

--- a/soweego/linker/feature_extraction.py
+++ b/soweego/linker/feature_extraction.py
@@ -9,6 +9,7 @@ __version__ = '1.0'
 __license__ = 'GPL-3.0'
 __copyright__ = 'Copyleft 2018, Hjfocs'
 
+import itertools
 import logging
 from typing import List, Set, Tuple, Union
 
@@ -80,11 +81,6 @@ class StringList(BaseCompareFeature):
 
             scores = []
             source_values, target_values = pair
-            # Paranoid checks to ensure we work on lists
-            if isinstance(source_values, str):
-                source_values = [source_values]
-            if isinstance(target_values, str):
-                target_values = [target_values]
 
             for source in source_values:
                 for target in target_values:

--- a/soweego/linker/feature_extraction.py
+++ b/soweego/linker/feature_extraction.py
@@ -202,7 +202,7 @@ class DateCompare(BaseCompareFeature):
         def check_date_equality(pair: Tuple[List[pd.Period], List[pd.Period]]):
             """
             Compares the target pd.Periods with the source pd.Periods which represent either
-            a birth or death date.
+            a birth or a death date.
 
             Returns the most optimistic match
             """

--- a/soweego/linker/feature_extraction.py
+++ b/soweego/linker/feature_extraction.py
@@ -198,8 +198,8 @@ class DateCompare(BaseCompareFeature):
         # we zip together the source column and the target column so that
         # they're easier to process
         concatenated = pd.Series(list(zip(source_column, target_column)))
-
-        def check_date_equality(pair: Tuple[Union[pd.Period, List[pd.Period]], pd.Period]):
+        
+        def check_date_equality(pair: Tuple[List[pd.Period], List[pd.Period]]):
             """
             Compares a target pd.Period with the source pd.Periods which represent either
             a birth or death date. The source date can be a list of possible dates.
@@ -209,7 +209,7 @@ class DateCompare(BaseCompareFeature):
 
             if _pair_has_any_null(pair):
                 LOGGER.debug(
-                    "Can't compare dates, the one of the values is NaN. Pair: %s", pair)
+                    "Can't compare dates, one of the values is NaN. Pair: %s", pair)
                 return np.nan
 
             s_items, t_items = pair

--- a/soweego/linker/feature_extraction.py
+++ b/soweego/linker/feature_extraction.py
@@ -207,34 +207,17 @@ class DateCompare(BaseCompareFeature):
             Returns the most optimistic match
             """
 
+            if _pair_has_any_null(pair):
+                LOGGER.debug(
+                    "Can't compare dates, the one of the values is NaN. Pair: %s", pair)
+                return np.nan
+
             s_items, t_items = pair
-
-            # if t_items or s_items is NaT then we can't compare, and we skip this pair
-            # we check if `items` is list so that we don't encounter the:
-            #   'truth value of an array with more than one element is ambiguous'
-            # error (`pd.isna` is applied elementwise). When any of the `items` is a list
-            # we know that it is also NaN, but we check for it anyway, just to be sure
-            # (and to catch possible bugs if this behavior is changed in the future)
-            if not isinstance(t_items, list) and pd.isna(t_items):
-                LOGGER.debug(
-                    "Can't compare dates, the target value is NaN. Pair: %s", pair)
-                return np.nan
-
-            if not isinstance(s_items, list) and pd.isna(s_items):
-                LOGGER.debug(
-                    "Can't compare dates, the source value is NaN. Pair: %s", pair)
-                return np.nan
 
             # will help us to keep track of the best score
             best = 0
 
             for s_date, t_date in itertools.product(s_items, t_items):
-
-                # if the current s_date is NaT then we can't compare, so we skip it
-                if pd.isna(s_date):
-                    LOGGER.debug(
-                        "Can't compare dates, the current Wikidata value is null. Current pair: %s", (s_date, t_date))
-                    continue
 
                 # get precision number for both dates
                 s_precision = constants.PD_PERIOD_PRECISIONS.index(

--- a/soweego/linker/workflow.py
+++ b/soweego/linker/workflow.py
@@ -312,9 +312,6 @@ def _shared_preprocessing(df, will_handle_dates):
         LOGGER.info('Handling dates ...')
         _handle_dates(df)
 
-    LOGGER.info('Stringifying lists with a single value ...')
-    df = _pull_out_from_single_value_list(df)
-
     return df
 
 
@@ -404,14 +401,6 @@ def handle_goal(goal):
     if goal not in ('training', 'classification'):
         raise ValueError(
             "Invalid 'goal' parameter: %s. Should be 'training' or 'classification'" % goal)
-
-
-def _pull_out_from_single_value_list(df):
-    # TODO this produces columns with either strings or lists, probably not ideal
-    df = df.applymap(lambda cell: cell[0] if isinstance(
-        cell, list) and len(cell) == 1 else cell)
-    log_dataframe_info(LOGGER, df, 'Stringified lists with a single value')
-    return df
 
 
 def _occupations_to_set(df):

--- a/soweego/linker/workflow.py
+++ b/soweego/linker/workflow.py
@@ -111,19 +111,6 @@ def _get_tids(qids_and_tids):
     return tids
 
 
-def train_test_build(catalog, entity, dir_io):
-    LOGGER.info("Building %s %s dataset for training and test, I/O directory: '%s'",
-                catalog, entity, dir_io)
-
-    # Wikidata
-    wd_df_reader = build_wikidata('training', catalog, entity, dir_io)
-
-    # Target
-    target_df_reader = build_target('training', catalog, entity, qids_and_tids)
-
-    return wd_df_reader, target_df_reader
-
-
 def preprocess(goal: str, wikidata_reader: JsonReader, target_reader: JsonReader) -> Tuple[
         Generator[pd.DataFrame, None, None], Generator[pd.DataFrame, None, None]]:
     handle_goal(goal)


### PR DESCRIPTION
Lists are no longer being stringified when datasets are being preprocessed. 

Closes #270 