### PR TITLE
Full names feature & post-classification rule

### DIFF
--- a/soweego/commons/constants.py
+++ b/soweego/commons/constants.py
@@ -129,7 +129,10 @@ CATALOG_ID = 'catalog_id'
 QID = 'qid'
 TID = 'tid'
 ALIAS = 'alias'
-PSEUDONYM = 'pseudonym'
+BIRTH_NAME = vocabulary.LINKER_PIDS[vocabulary.BIRTH_NAME]
+FAMILY_NAME = vocabulary.LINKER_PIDS[vocabulary.FAMILY_NAME]
+GIVEN_NAME = vocabulary.LINKER_PIDS[vocabulary.GIVEN_NAME]
+PSEUDONYM = vocabulary.LINKER_PIDS[vocabulary.PSEUDONYM]
 DATE_OF_BIRTH = vocabulary.LINKER_PIDS[vocabulary.DATE_OF_BIRTH]
 DATE_OF_DEATH = vocabulary.LINKER_PIDS[vocabulary.DATE_OF_DEATH]
 # Consistent with BaseEntity
@@ -143,6 +146,11 @@ URL_TOKENS = 'url_tokens'
 # Consistent with BaseNlpEntity
 DESCRIPTION = 'description'
 DESCRIPTION_TOKENS = 'description_tokens'
+# Target-specific column names
+REAL_NAME = 'real_name'
+# Cluster of fields with names
+NAME_FIELDS = (NAME, ALIAS, BIRTH_NAME, FAMILY_NAME,
+               GIVEN_NAME, PSEUDONYM, REAL_NAME)
 
 # File names
 WD_TRAINING_SET = 'wikidata_%s_%s_training_set.jsonl.gz'

--- a/soweego/linker/classify.py
+++ b/soweego/linker/classify.py
@@ -55,7 +55,7 @@ def cli(classifier, target, target_type, name_rule, upload, sandbox, threshold, 
             _upload(chunk, target, sandbox)
 
         chunk.to_csv(os.path.join(dir_io, constants.LINKER_RESULT %
-                                  (target, target_type, classifier)), mode='a', header=True)
+                                  (target, target_type, classifier)), mode='a', header=False)
 
 
 def _upload(predictions, catalog, sandbox):

--- a/soweego/linker/classify.py
+++ b/soweego/linker/classify.py
@@ -114,13 +114,18 @@ def execute(catalog, entity, model, name_rule, threshold, dir_io):
 
 
 def _zero_when_different_names(prediction, wikidata, target):
+    wd_names, target_names = set(), set()
     qid, tid = prediction.name
-    # TODO use constants.NAME_FIELDS, not only constants.NAME
-    wd_names = wikidata.loc[qid][constants.NAME]
-    target_names = target.loc[tid][constants.NAME]
-    wd_names = set(wd_names) if isinstance(wd_names, list) else set([wd_names])
-    target_names = set(target_names) if isinstance(
-        target_names, list) else set([target_names])
+    for column in constants.NAME_FIELDS:
+        if wikidata.get(column) is not None:
+            values = wikidata.loc[qid][column]
+            if values is not nan:
+                wd_names.update(set(values))
+        if target.get(column) is not None:
+            values = target.loc[tid][column]
+            if values is not nan:
+                target_names.update(set(values))
+
     return 0.0 if wd_names.isdisjoint(target_names) else prediction[0]
 
 

--- a/soweego/linker/classify.py
+++ b/soweego/linker/classify.py
@@ -48,7 +48,7 @@ def cli(classifier, target, target_type, name_rule, upload, sandbox, threshold, 
     if not os.path.isfile(model_path):
         err_msg = 'No classifier model found at path: %s ' % model_path
         LOGGER.critical('File does not exist - ' + err_msg)
-        raise FileExistsError(err_msg)
+        raise FileNotFoundError(err_msg)
 
     for chunk in execute(target, target_type, model_path, name_rule, threshold, dir_io):
         if upload:
@@ -115,6 +115,7 @@ def execute(catalog, entity, model, name_rule, threshold, dir_io):
 
 def _zero_when_different_names(prediction, wikidata, target):
     qid, tid = prediction.name
+    # TODO use constants.NAME_FIELDS, not only constants.NAME
     wd_names = wikidata.loc[qid][constants.NAME]
     target_names = target.loc[tid][constants.NAME]
     wd_names = set(wd_names) if isinstance(wd_names, list) else set([wd_names])

--- a/soweego/linker/feature_extraction.py
+++ b/soweego/linker/feature_extraction.py
@@ -141,12 +141,12 @@ class StringList(BaseCompareFeature):
         return _metric_sparse_cosine(vectors[:len(source_column)], vectors[len(source_column):])
 
 
-class UrlList(BaseCompareFeature):
-    name = 'url_list'
-    description = 'Compare pairs of lists with URL values'
+class ExactList(BaseCompareFeature):
+    name = 'exact_list'
+    description = 'Compare pairs of lists through exact match on each pair of elements.'
 
     def __init__(self, left_on, right_on, agree_value=1.0, disagree_value=0.0, missing_value=constants.FEATURE_MISSING_VALUE, label=None):
-        super(UrlList, self).__init__(left_on, right_on, label=label)
+        super(ExactList, self).__init__(left_on, right_on, label=label)
         self.agree_value = agree_value
         self.disagree_value = disagree_value
         self.missing_value = missing_value
@@ -157,7 +157,7 @@ class UrlList(BaseCompareFeature):
         def exact_apply(pair):
             if _pair_has_any_null(pair):
                 LOGGER.debug(
-                    "Can't compare URLs, the pair contains null values: %s", pair)
+                    "Can't compare, the pair contains null values: %s", pair)
                 return np.nan
 
             scores = []
@@ -198,7 +198,7 @@ class DateCompare(BaseCompareFeature):
         # we zip together the source column and the target column so that
         # they're easier to process
         concatenated = pd.Series(list(zip(source_column, target_column)))
-        
+
         def check_date_equality(pair: Tuple[List[pd.Period], List[pd.Period]]):
             """
             Compares the target pd.Periods with the source pd.Periods which represent either
@@ -262,25 +262,9 @@ class DateCompare(BaseCompareFeature):
         return fillna(concatenated.apply(check_date_equality), self.missing_value)
 
 
-def _pair_has_any_null(pair):
-    if not all(pair):
-        return True
-
-    source_is_null, target_is_null = pd.isna(pair[0]), pd.isna(pair[1])
-    if isinstance(source_is_null, np.ndarray):
-        source_is_null = source_is_null.all()
-    if isinstance(target_is_null, np.ndarray):
-        target_is_null = target_is_null.all()
-
-    if source_is_null or target_is_null:
-        return True
-
-    return False
-
-
 class SimilarTokens(BaseCompareFeature):
     name = 'SimilarTokens'
-    description = 'Compare pairs of lists with string values based on shared tokens'
+    description = 'Compare pairs of lists with string values based on shared tokens.'
 
     def __init__(self, left_on, right_on, agree_value=1.0, disagree_value=0.0, missing_value=constants.FEATURE_MISSING_VALUE, label=None):
         super(SimilarTokens, self).__init__(left_on, right_on, label=label)
@@ -403,3 +387,19 @@ class OccupationQidSet(BaseCompareFeature):
             return n_shared_items / min_length
 
         return fillna(concatenated.apply(check_occupation_equality), self.missing_value)
+
+
+def _pair_has_any_null(pair):
+    if not all(pair):
+        return True
+
+    source_is_null, target_is_null = pd.isna(pair[0]), pd.isna(pair[1])
+    if isinstance(source_is_null, np.ndarray):
+        source_is_null = source_is_null.all()
+    if isinstance(target_is_null, np.ndarray):
+        target_is_null = target_is_null.all()
+
+    if source_is_null or target_is_null:
+        return True
+
+    return False

--- a/soweego/linker/feature_extraction.py
+++ b/soweego/linker/feature_extraction.py
@@ -170,7 +170,7 @@ class ExactList(BaseCompareFeature):
                         scores.append(self.agree_value)
                     else:
                         scores.append(self.disagree_value)
-            return np.average(scores)
+            return max(scores)
 
         return fillna(concatenated.apply(exact_apply), self.missing_value)
 

--- a/soweego/linker/workflow.py
+++ b/soweego/linker/workflow.py
@@ -309,9 +309,11 @@ def _shared_preprocessing(df, will_handle_dates):
 
 def _normalize_values(values):
     normalized_values = set()
-    if values is nan:
+    if values is nan or not all(values):
         return nan
     for value in values:
+        if not value:
+            continue
         _, normalized = text_utils.normalize(value)
         normalized_values.add(normalized)
     return list(normalized_values) if normalized_values else nan

--- a/soweego/linker/workflow.py
+++ b/soweego/linker/workflow.py
@@ -313,7 +313,7 @@ def _shared_preprocessing(df, will_handle_dates):
 
 def _normalize_values(values):
     normalized_values = set()
-    if values is nan or not all(values):
+    if values is nan or not any(values):
         return nan
     for value in values:
         if not value:


### PR DESCRIPTION
This PR implements #262 task 1 + task 2. More specifically:
- fields with names (see `constants`) are **normalized** during **preprocessing**;
- an optional post-classification rule filters links with disjoint sets of fields with names;
- the previously called `UrlList` feature is now used for names too;
- the feature returns the **maximum** comparison score between field lists, instead of the average.