### PR TITLE
Rotten URLs for catalog providers

### DIFF
--- a/soweego/commons/url_utils.py
+++ b/soweego/commons/url_utils.py
@@ -5,13 +5,14 @@
 
 __author__ = 'Marco Fossati'
 __email__ = 'fossati@spaziodati.eu'
-__version__ = '1.0'
+__version__ = '2.0'
 __license__ = 'GPL-3.0'
-__copyright__ = 'Copyleft 2018, Hjfocs'
+__copyright__ = 'Copyleft 2021, Hjfocs'
 
 import logging
 import re
 from functools import lru_cache
+from typing import Optional
 from urllib.parse import unquote, urlsplit
 
 import regex
@@ -100,7 +101,13 @@ def validate(url):
 
 
 @lru_cache()
-def resolve(url):
+def resolve(url: str) -> Optional[str]:
+    """Try to resolve an URL via a set of strategies.
+
+    :param url: an URL
+    :return: the resolved URL (may differ from the given one), or ``None``
+    if the resolution attempt failed
+    """
     # Don't show warnings in case of unverified HTTPS requests
     disable_warnings(InsecureRequestWarning)
     # Some Web sites return 4xx just because of a non-browser user agent header
@@ -122,42 +129,42 @@ def resolve(url):
             response = get(url, headers=browser_ua, stream=True, verify=False)
         except Exception as unexpected_error:
             LOGGER.warning(
-                'Dropping URL that led to an unexpected error: <%s> - Reason: %s',
+                'Unexpected error: <%s> - Reason: %s',
                 url,
                 unexpected_error,
             )
             return None
     except requests.exceptions.Timeout as timeout:
         LOGGER.info(
-            'Dropping URL that led to a request timeout: <%s> - Reason: %s',
+            'Request timeout: <%s> - Reason: %s',
             url,
             timeout,
         )
         return None
     except requests.exceptions.TooManyRedirects as too_many_redirects:
         LOGGER.info(
-            'Dropping URL because of too many redirects: <%s> - %s',
+            'Too many redirects: <%s> - %s',
             url,
             too_many_redirects,
         )
         return None
     except requests.exceptions.ConnectionError as connection_error:
         LOGGER.info(
-            'Dropping URL that led to an aborted connection: <%s> - Reason: %s',
+            'Aborted connection: <%s> - Reason: %s',
             url,
             connection_error,
         )
         return None
     except Exception as unexpected_error:
         LOGGER.warning(
-            'Dropping URL that led to an unexpected error: <%s> - Reason: %s',
+            'Unexpected error: <%s> - Reason: %s',
             url,
             unexpected_error,
         )
         return None
     if not response.ok:
         LOGGER.info(
-            "Dropping dead URL that returned HTTP status '%s' (%d): <%s>",
+            "HTTP status '%s' (%d): <%s>",
             response.reason,
             response.status_code,
             url,

--- a/soweego/commons/url_utils.py
+++ b/soweego/commons/url_utils.py
@@ -129,37 +129,27 @@ def resolve(url: str) -> Optional[str]:
             response = get(url, headers=browser_ua, stream=True, verify=False)
         except Exception as unexpected_error:
             LOGGER.warning(
-                'Unexpected error: <%s> - Reason: %s',
-                url,
-                unexpected_error,
+                'Unexpected error: <%s> - Reason: %s', url, unexpected_error,
             )
             return None
     except requests.exceptions.Timeout as timeout:
         LOGGER.info(
-            'Request timeout: <%s> - Reason: %s',
-            url,
-            timeout,
+            'Request timeout: <%s> - Reason: %s', url, timeout,
         )
         return None
     except requests.exceptions.TooManyRedirects as too_many_redirects:
         LOGGER.info(
-            'Too many redirects: <%s> - %s',
-            url,
-            too_many_redirects,
+            'Too many redirects: <%s> - %s', url, too_many_redirects,
         )
         return None
     except requests.exceptions.ConnectionError as connection_error:
         LOGGER.info(
-            'Aborted connection: <%s> - Reason: %s',
-            url,
-            connection_error,
+            'Aborted connection: <%s> - Reason: %s', url, connection_error,
         )
         return None
     except Exception as unexpected_error:
         LOGGER.warning(
-            'Unexpected error: <%s> - Reason: %s',
-            url,
-            unexpected_error,
+            'Unexpected error: <%s> - Reason: %s', url, unexpected_error,
         )
         return None
     if not response.ok:

--- a/soweego/importer/cli.py
+++ b/soweego/importer/cli.py
@@ -5,15 +5,15 @@
 
 __author__ = 'Marco Fossati'
 __email__ = 'fossati@spaziodati.eu'
-__version__ = '1.0'
+__version__ = '2.0'
 __license__ = 'GPL-3.0'
-__copyright__ = 'Copyleft 2018, Hjfocs'
+__copyright__ = 'Copyleft 2021, Hjfocs'
 
 import click
 
-from soweego.importer.importer import check_links_cli, import_cli
+from soweego.importer.importer import check_urls_cli, import_cli
 
-CLI_COMMANDS = {'import': import_cli, 'check_urls': check_links_cli}
+CLI_COMMANDS = {'import': import_cli, 'check_urls': check_urls_cli}
 
 
 @click.group(name='importer', commands=CLI_COMMANDS)

--- a/soweego/importer/importer.py
+++ b/soweego/importer/importer.py
@@ -35,6 +35,7 @@ DUMP_EXTRACTOR = {
 }
 ROTTEN_URLS_FNAME = '{catalog}_{entity}_rotten_urls.txt'
 
+
 @click.command()
 @click.argument(
     'catalog', type=click.Choice(target_database.supported_targets())
@@ -70,10 +71,7 @@ def _resolve_url(res):
     'catalog', type=click.Choice(target_database.supported_targets())
 )
 @click.option(
-    '-d',
-    '--drop',
-    is_flag=True,
-    help=f'Drop rotten URLs from the DB.',
+    '-d', '--drop', is_flag=True, help=f'Drop rotten URLs from the DB.',
 )
 @click.option(
     '--dir-io',
@@ -97,7 +95,8 @@ def check_urls_cli(catalog, drop, dir_io):
         if not link_entity:
             LOGGER.info(
                 '%s %s does not have a links table. Skipping ...',
-                catalog, entity
+                catalog,
+                entity,
             )
             continue
 
@@ -138,12 +137,19 @@ def check_urls_cli(catalog, drop, dir_io):
 
         LOGGER.info(
             "Total %s %s rotten URLs dumped to '%s': %d / %d",
-            catalog, entity, out_path, rotten, total
+            catalog,
+            entity,
+            out_path,
+            rotten,
+            total,
         )
         if drop:
             LOGGER.info(
                 'Total %s %s rotten URLs dropped from the DB: %d / %d',
-                catalog, entity, rotten, removed
+                catalog,
+                entity,
+                rotten,
+                removed,
             )
 
 


### PR DESCRIPTION
This (tiny) PR updates the URL sanity check functionality. It introduces two features:
1. dump text files with rotten URLs, to be sent to catalog providers, see #150 and #151 
2. don't delete rotten URLs from our DB by default, add a boolean CLI flag instead